### PR TITLE
revert fail on error

### DIFF
--- a/anybox/recipe/odoo/runtime/upgrade.py
+++ b/anybox/recipe/odoo/runtime/upgrade.py
@@ -14,7 +14,6 @@ from argparse import ArgumentDefaultsHelpFormatter
 from argparse import SUPPRESS
 from datetime import datetime
 from math import ceil
-from StringIO import StringIO
 
 from ..utils import total_seconds
 from .session import Session
@@ -157,18 +156,7 @@ def upgrade(upgrade_script, upgrade_callable, conf):
     upgrade_module = imp.load_source('anybox.recipe.odoo.upgrade_openerp',
                                      upgrade_script)
 
-    # Catch errors in a buffer
-    buf = StringIO()
-    bufferHandler = logging.StreamHandler(buf)
-    bufferHandler.setFormatter(DBFormatter(format))
-    bufferHandler.setLevel(logging.ERROR)
-    logging.getLogger().addHandler(bufferHandler)
-
     statuscode = getattr(upgrade_module, upgrade_callable)(session, logger)
-    buf.seek(0)
-    if buf.read():
-        statuscode = 1
-
     if statuscode is None or statuscode == 0:
         if pkg_version is not None:
             logger.info("setting version %s in database" % pkg_version)
@@ -182,6 +170,5 @@ def upgrade(upgrade_script, upgrade_callable, conf):
         logger.error("Please check logs at %s" % log_path)
 
     session.close()
-    buf.close()
     log_file.close()
     sys.exit(statuscode)


### PR DESCRIPTION
Even if missing dependencies are resolved during the upgrade, they will
still be logged as errors and make the upgrade fail unnecessarily.