### PR TITLE
[FIX] Pinning of git merges

### DIFF
--- a/anybox/recipe/odoo/vcs/git.py
+++ b/anybox/recipe/odoo/vcs/git.py
@@ -413,10 +413,12 @@ class GitRepo(BaseRepo):
                                    "or non git local directory %s" %
                                    self.target_dir)
             os.chdir(self.target_dir)
-            rtype, sha = self.query_remote_ref(BUILDOUT_ORIGIN, revision)
+            rtype, sha = self.query_remote_ref(self.url, revision)
             if rtype is None and ishex(revision):
                 self.fetch_remote_sha(revision, checkout=False)
-            cmd = ['git', 'pull', self.url, revision]
+                cmd = ['git', 'merge', revision]
+            else:
+                cmd = ['git', 'pull', self.url, revision]
             if self.git_version >= (1, 7, 10):
                 # --edit and --no-edit appear with Git 1.7.10
                 # see Documentation/RelNotes/1.7.10.txt of Git


### PR DESCRIPTION
This change allows the buildout recipe to support merges like
    git https://github.com/MyTeam/odoo parts/odoo 01234567890abcdef branch=my_branch

By checking the git reference against the correct repo, the remote revision
will be imported correctly in the local repo. It can then be merged (not
pulled) into the local branch.

Prerequisite of UAASDEV-4422

I've proposed this upstream here: https://github.com/anybox/anybox.recipe.odoo/pull/122